### PR TITLE
Add `pretty_print` module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ For example: `/std/fs/path.lua` is required with `require 'std.fs.path'`.
 - [ ] json
 - [ ] net
 - [x] pathjoin
-- [ ] pretty-print
+- [x] pretty-print
 - [x] process
 - [x] querystring
 - [ ] readline

--- a/std/pretty-print.lua
+++ b/std/pretty-print.lua
@@ -1,0 +1,67 @@
+---@class theme
+---@field property string
+---@field sep string
+---@field braces string
+---@field nil string
+---@field boolean string
+---@field number string
+---@field string string
+---@field quotes string
+---@field escape string
+---@field function string
+---@field thread string
+---@field table string
+---@field userdata string
+---@field cdata string
+---@field err string
+---@field success string
+---@field failure string
+---@field highlight string
+local _theme = {}
+
+---@alias uv_stream_t userdata
+
+---@class prettyprintlib
+---@field themes table<integer, theme>
+---@field currentTheme theme
+---@field stdin uv_stream_t
+---@field stdout uv_stream_t
+---@field stderr uv_stream_t
+local prettyPrint = {}
+
+--- Functions that print something
+
+---@vararg string
+function prettyPrint.prettyPrint(...) end
+
+---@vararg string
+function prettyPrint.print(...) end
+
+-- Functions that transform strings
+
+---@param str string
+---@param depth? integer
+---@param noColor? boolean
+---@return string
+function prettyPrint.dump(str, depth, noColor) end
+
+---@param str string
+---@return string
+function prettyPrint.strip(str) end
+
+---@param colorName string
+---@return string
+function prettyPrint.color(colorName) end
+
+---@param str string
+---@param colorName string
+---@param resetName string
+---@return string
+function prettyPrint.colorize(str, colorName, resetName) end
+
+--- Functions that modify the current theme
+
+---@param theme theme|integer
+function prettyPrint.setTheme(theme) end
+
+return prettyPrint

--- a/std/pretty_print.lua
+++ b/std/pretty_print.lua
@@ -1,4 +1,4 @@
----@class theme
+---@class Theme
 ---@field property string
 ---@field sep string
 ---@field braces string
@@ -17,51 +17,51 @@
 ---@field success string
 ---@field failure string
 ---@field highlight string
-local _theme = {}
+local _Theme = {}
 
 ---@alias uv_stream_t userdata
 
----@class prettyprintlib
----@field themes table<integer, theme>
----@field currentTheme theme
+---@class pretty_printlib
+---@field themes table<integer, Theme>
+---@field current_theme Theme
 ---@field stdin uv_stream_t
 ---@field stdout uv_stream_t
 ---@field stderr uv_stream_t
-local prettyPrint = {}
+local pretty_print = {} -- TODO: Come up with a better name
 
 --- Functions that print something
 
 ---@vararg string
-function prettyPrint.prettyPrint(...) end
+function pretty_print.prettyPrint(...) end
 
 ---@vararg string
-function prettyPrint.print(...) end
+function pretty_print.print(...) end
 
 -- Functions that transform strings
 
 ---@param str string
 ---@param depth? integer
----@param noColor? boolean
+---@param no_color? boolean
 ---@return string
-function prettyPrint.dump(str, depth, noColor) end
+function pretty_print.dump(str, depth, no_color) end
 
 ---@param str string
 ---@return string
-function prettyPrint.strip(str) end
+function pretty_print.strip(str) end
 
----@param colorName string
+---@param color_name string
 ---@return string
-function prettyPrint.color(colorName) end
+function pretty_print.color(color_name) end
 
 ---@param str string
----@param colorName string
----@param resetName string
+---@param color_name string
+---@param reset_name string
 ---@return string
-function prettyPrint.colorize(str, colorName, resetName) end
+function pretty_print.colorize(str, color_name, reset_name) end
 
 --- Functions that modify the current theme
 
----@param theme theme|integer
-function prettyPrint.setTheme(theme) end
+---@param theme Theme|integer
+function pretty_print.setTheme(theme) end
 
-return prettyPrint
+return pretty_print


### PR DESCRIPTION
Changes from current Luvit 2.x implementation:

1. `dump()` now takes a `depth` integer instead of a `recurse` boolean
2. Swapped order of arguments to `colorize()`
3. Renamed the `theme` field to `current_theme`
4. Exposed the `themes` table as a field
5. Renamed `loadColors()` to `setTheme()`
6. `setTheme()` can now take a theme table for custom themes

[As was discussed on Discord](https://ptb.discord.com/channels/377572091869790210/468625729211334686/945837071002656808), the module could also use a different name, suggestions for which are welcome.