### PR TITLE
Alternate `timer` function names

### DIFF
--- a/std/timer.lua
+++ b/std/timer.lua
@@ -14,23 +14,21 @@ function timer.sleep(delay, thread) end
 ---@param ... any
 ---@return uv_timer_t
 ---@error nil, string, string
-function timer.setTimeout(delay, callback, ...) end
+function timer.delay(delay, callback, ...) end
 
 ---@param delay number
 ---@param callback function
 ---@param ... any
 ---@return uv_timer_t
 ---@error nil, string, string
-function timer.setInterval(delay, callback, ...) end
-
----@param timer_t uv_timer_t
-function timer.clearInterval(timer_t) end
-
-timer.clearTimeout = timer.clearInterval
+function timer.periodically(delay, callback, ...) end
 
 ---@param callback function
 ---@param ... any
 ---@error nil, string, string
-function timer.setImmediate(callback, ...) end
+function timer.immediately(callback, ...) end
+
+---@param timer_t uv_timer_t
+function timer.clear(timer_t) end
 
 return timer


### PR DESCRIPTION
Yet another proposal. I find these alternate names to be more understandable than the current ones.

`setTimeout` -> `delay`
`setInterval` -> `periodically`
`setImmediate` -> `immediately`
`clearInterval` -> `clear`
`clearTimeout` -> `clear`