### PR TITLE
annotations: use fun instead of function

### DIFF
--- a/std/codec.lua
+++ b/std/codec.lua
@@ -1,14 +1,14 @@
 ---@class std.codec
 local codec = {}
 
----@alias std.codec.reader function function() -> string
----@alias std.codec.writer function function(string) -> nil
+---@alias std.codec.reader fun(): string
+---@alias std.codec.writer fun(data: string)
 
----@alias std.codec.encoded_reader function function() -> any
----@alias std.codec.encoded_writer function function(any) -> nil
+---@alias std.codec.encoded_reader fun(): any
+---@alias std.codec.encoded_writer fun(data: any)
 
----@alias std.codec.decoder function function(string, integer) -> any, integer
----@alias std.codec.encoder function function(any) -> string
+---@alias std.codec.decoder fun(data: string, offset: integer): any, integer
+---@alias std.codec.encoder fun(data: any): string
 
 codec.http = require('std.codec.http')
 

--- a/std/codec.lua
+++ b/std/codec.lua
@@ -2,7 +2,7 @@
 local codec = {}
 
 ---@alias std.codec.reader fun(): string
----@alias std.codec.writer fun(data: string)
+---@alias std.codec.writer fun(buffer: string)
 
 ---@alias std.codec.encoded_reader fun(): any
 ---@alias std.codec.encoded_writer fun(data: any)

--- a/std/fs.lua
+++ b/std/fs.lua
@@ -91,7 +91,7 @@ function fs.rmdir(path) end
 
 -- note: abstract over fs_scandir + fs_scandir_next
 ---@param path path_t
----@return fun(name: string, type: string)
+---@return fun(): string, string
 ---@error nil, string, string
 function fs.scandir(path) end
 

--- a/std/fs.lua
+++ b/std/fs.lua
@@ -91,7 +91,7 @@ function fs.rmdir(path) end
 
 -- note: abstract over fs_scandir + fs_scandir_next
 ---@param path path_t
----@return function
+---@return fun(name: string, type: string)
 ---@error nil, string, string
 function fs.scandir(path) end
 

--- a/std/timer.lua
+++ b/std/timer.lua
@@ -10,20 +10,20 @@ local timer = {}
 function timer.sleep(delay, thread) end
 
 ---@param delay number
----@param callback function
+---@param callback fun(...: any)
 ---@param ... any
 ---@return uv_timer_t
 ---@error nil, string, string
 function timer.delay(delay, callback, ...) end
 
 ---@param delay number
----@param callback function
+---@param callback fun(...: any)
 ---@param ... any
 ---@return uv_timer_t
 ---@error nil, string, string
 function timer.periodically(delay, callback, ...) end
 
----@param callback function
+---@param callback fun(...: any)
 ---@param ... any
 ---@error nil, string, string
 function timer.immediately(callback, ...) end


### PR DESCRIPTION
Sumneko's language server offers the annotation `fun(arg_name: type): return_type` to annotate functions.

This PR converts most of the `function` types into that, with some exceptions to the modules where I have no clue what the arguments/returns look like.

codec.lua should be reviewed for argument names, not so sure about `data` vs `chunk`.