### PR TITLE
codec: add websocket field

### DIFF
--- a/std/codec.lua
+++ b/std/codec.lua
@@ -11,6 +11,7 @@ local codec = {}
 ---@alias std.codec.encoder function function(any) -> string
 
 codec.http = require('std.codec.http')
+codec.websocket = require('std.codec.websocket')
 
 ---@param read std.codec.reader
 ---@param decode std.codec.decoder


### PR DESCRIPTION
I see `codec.http`, so I suppose each codec should be exposed in the same way.