### PR TITLE
README: merge https into http

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ For example: `/std/fs/path.lua` is required with `require 'std.fs.path'`.
 - [x] http-codec
 - [ ] http-header
 - [ ] http
-- [ ] https
 - [ ] json
 - [ ] net
 - [x] pathjoin
@@ -81,4 +80,5 @@ For example: `/std/fs/path.lua` is required with `require 'std.fs.path'`.
 - [ ] weblit-server: needs own repo
 - [ ] weblit-websocket: needs own repo
 - [ ] tls: replace with secure-socket
-- [ ] coro-http: merge with http, https and http-header
+- [ ] https: merge with http
+- [ ] coro-http: merge with http and http-header


### PR DESCRIPTION
Context: issue #21.

This PR takes the path of merging `https` into `http` and clarifies that by explicitly listing `https` as to be removed.

Shall not be merged until an agreement is reached in #21.